### PR TITLE
Ignore EX11 synthetic data and generate programmatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore synthetic data for Exercise 11
+exercises/EX11_synthetic/

--- a/exercises/EX11_solutions.ipynb
+++ b/exercises/EX11_solutions.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6fb718c4",
+   "metadata": {},
+   "source": [
+    "# EX11 Solutions\n",
+    "\n",
+    "This notebook generates synthetic data for Exercise 11 when executed. The generated files are ignored by git via `.gitignore`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "31871933",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-15T20:01:01.895197Z",
+     "iopub.status.busy": "2025-08-15T20:01:01.894917Z",
+     "iopub.status.idle": "2025-08-15T20:01:02.061286Z",
+     "shell.execute_reply": "2025-08-15T20:01:02.060114Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 5 images\n",
+      "Poses shape: (5, 4, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import glob\n",
+    "import numpy as np\n",
+    "from PIL import Image\n",
+    "\n",
+    "DATA_DIR = 'EX11_synthetic'\n",
+    "os.makedirs(DATA_DIR, exist_ok=True)\n",
+    "\n",
+    "poses = []\n",
+    "for idx in range(1, 6):\n",
+    "    img = np.zeros((64, 64, 3), dtype=np.uint8)\n",
+    "    img[..., 0] = idx * 40\n",
+    "    img[..., 1] = np.arange(64).reshape(64, 1)\n",
+    "    img[..., 2] = np.arange(64).reshape(1, 64)\n",
+    "    Image.fromarray(img).save(os.path.join(DATA_DIR, f'{idx:06d}.png'))\n",
+    "    pose = np.eye(4)\n",
+    "    pose[0, 3] = idx * 0.1\n",
+    "    poses.append(pose)\n",
+    "poses = np.stack(poses)\n",
+    "np.save(os.path.join(DATA_DIR, 'poses.npy'), poses)\n",
+    "\n",
+    "print('Generated', len(glob.glob(os.path.join(DATA_DIR, '*.png'))), 'images')\n",
+    "print('Poses shape:', poses.shape)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Ignore EX11_synthetic directory to keep binary data out of git
- Add EX11_solutions notebook that programmatically generates synthetic images and poses

## Testing
- `jupyter nbconvert --to notebook --execute --inplace exercises/EX11_solutions.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_689f907dc3cc832fb4b1ec1b234cd300